### PR TITLE
Closing issues 72 & 73

### DIFF
--- a/inc/custom-admin.php
+++ b/inc/custom-admin.php
@@ -118,3 +118,29 @@ function faithmade_from_name(){
 	return 'Faithmade';
 }
 add_filter('wp_mail_from_name','mail_from_name');
+
+/**
+ * Removes CoSchedule Redirect on Activation on Site Creation
+ * 
+ * @internal CoSchedule has a singleton core class and their is not access to the
+ * instance outside of the class, so we have to hook redirect.
+ */
+function faithmade_maybe_suppress_coschedule_redirect( $location, $status ) {
+	// Bail if this is any redirect except coschedule's
+	if( ! strpos( $location, 'tm_coschedule_calendar' ) ) {
+		return $location;
+	}
+
+	// If we are coming from wp-admin/plugins.php we can assume this was user initiated,
+	// in which case, we want them to redirect to the setup page.
+	if( false !== strpos( parse_url( $_SERVER['HTTP_REFERER'], PHP_URL_PATH), 'wp-admin/plugins.php' ) ) {
+		return $location;
+	}
+
+	// This should be our unique use case where users are coming in to a fresh dashboard without having
+	// expired the coschedule activation redirect function.  In this case, override it and send them home.
+	return admin_url();
+}
+if( is_admin() ) {
+	add_action( 'wp_redirect', 'faithmade_maybe_suppress_coschedule_redirect', 10, 2 );
+}

--- a/inc/custom-admin.php
+++ b/inc/custom-admin.php
@@ -20,6 +20,8 @@ function faithmade_custom_css() {
 function faithmade_remove_admin_items() {
 	if( ! is_super_admin() ){
 		remove_menu_page( 'plugins.php' );
+	}
+	if( ! current_user_can( 'switch_themes') ) {
 		remove_menu_page( 'tools.php' );
 	}
 }


### PR DESCRIPTION
- Allows Site Admins to see "Tools" in Dashboard Menu so they can import sites.
- Suppresses a redirect from CoSchedule when users are first redirected to the their site after site creation.
